### PR TITLE
:put_litter_in_its_place: Revert segment search changes

### DIFF
--- a/app/lib/getPharmacies.js
+++ b/app/lib/getPharmacies.js
@@ -17,27 +17,34 @@ function getDistanceInMiles(start, end) {
   return distanceInMeters / metersInAMile;
 }
 
-function nearbyRingSearch(searchPoint, geo, limits, searchRing) {
-  const numberOfOpenToReturn = limits.open;
+function nearby(searchPoint, geo, searchLimits) {
+  assert(searchPoint, 'searchPoint can not be null');
+  assert(searchPoint.latitude, 'searchPoint must contain a property named latitude');
+  assert(searchPoint.longitude, 'searchPoint must contain a property named longitude');
+
+  assert(geo, 'geo can not be null');
+  assert.equal(typeof (geo.nearBy), 'function',
+    'geo must contain a nearBy function');
+
+  const defaultNearbyLimit = 10;
+  const defaultOpenLimit = 3;
+
+  const limits = searchLimits || {};
+  limits.nearby = limits.nearby || defaultNearbyLimit;
+  limits.open = limits.open || defaultOpenLimit;
+
+  assert.equal(typeof (limits.nearby), 'number', 'nearby limit must be a number');
+  assert.equal(typeof (limits.open), 'number', 'open limit must be a number');
+  assert(limits.nearby >= 1, 'nearby limit must be at least 1');
+  assert(limits.open >= 1, 'open limit must be at least 1');
+
   const openServices = [];
   let serviceCount = 0;
   let openServiceCount = 0;
-  let nearbyGeo;
 
   log.debug('get-nearby-results-start');
-  if (searchRing.start < 1) {
-    nearbyGeo =
-      geo.nearBy(
-        searchPoint.latitude,
-        searchPoint.longitude,
-        searchRing.end * metersInAMile);
-  } else {
-    nearbyGeo =
-      geo.nearBy(
-        searchPoint.latitude,
-        searchPoint.longitude,
-        [(searchRing.start * metersInAMile) + 1, searchRing.end * metersInAMile]);
-  }
+  const nearbyGeo =
+    geo.nearBy(searchPoint.latitude, searchPoint.longitude, 50 * metersInAMile);
   log.debug('get-nearby-results-end');
 
   log.debug(`Found ${nearbyGeo.length} nearby results`);
@@ -80,85 +87,22 @@ function nearbyRingSearch(searchPoint, geo, limits, searchRing) {
     item.openingTimesMessage = openingTimesMessage;
     item.isOpen = isOpen;
 
-    if (isOpen && openServiceCount < numberOfOpenToReturn) {
+    if (isOpen && openServiceCount < limits.open) {
       openServiceCount += 1;
       openServices.push(utils.deepClone(item));
     }
 
     serviceCount += 1;
 
-    if (openServiceCount >= numberOfOpenToReturn && serviceCount >= limits.nearby) {
+    if (openServiceCount >= limits.open && serviceCount >= limits.nearby) {
       break;
     }
   }
   log.debug('filter-open-results-end');
 
   return {
-    nearbyServices: sortedOrgs,
+    nearbyServices: sortedOrgs.slice(0, limits.nearby),
     openServices,
-  };
-}
-
-function nearby(searchPoint, geo, searchLimits) {
-  assert(searchPoint, 'searchPoint can not be null');
-  assert(searchPoint.latitude, 'searchPoint must contain a property named latitude');
-  assert(searchPoint.longitude, 'searchPoint must contain a property named longitude');
-
-  assert(geo, 'geo can not be null');
-  assert.equal(typeof (geo.nearBy), 'function', 'geo must contain a nearBy function');
-
-  const defaultNearbyLimit = 10;
-  const defaultOpenLimit = 3;
-
-  const limits = searchLimits || {};
-  limits.nearby = limits.nearby || defaultNearbyLimit;
-  limits.open = limits.open || defaultOpenLimit;
-
-  assert.equal(typeof (limits.nearby), 'number', 'nearby limit must be a number');
-  assert.equal(typeof (limits.open), 'number', 'open limit must be a number');
-  assert(limits.nearby >= 1, 'nearby limit must be at least 1');
-  assert(limits.open >= 1, 'open limit must be at least 1');
-
-  let openServices = [];
-  let nearbyServices = [];
-
-  const searchRing = {
-    start: 0,
-    end: 10,
-    increment: 10,
-  };
-
-  let loopCount = 0;
-  const idProperty = 'identifier';
-
-  while (openServices.length < limits.open + 1
-    && nearbyServices.length < limits.nearby + 1) {
-    log.info(`nearby-ring-search-start-#${loopCount + 1}`);
-    const ringSearchResults = nearbyRingSearch(searchPoint, geo, limits, searchRing);
-    log.info(`nearby-ring-search-end-#${loopCount + 1}`);
-
-    openServices =
-        utils.removeDuplicates(
-          openServices.concat(
-            ringSearchResults.openServices), idProperty);
-    nearbyServices =
-        utils.removeDuplicates(
-          nearbyServices.concat(
-            ringSearchResults.nearbyServices), idProperty);
-
-    searchRing.start += searchRing.increment;
-    searchRing.end += searchRing.increment;
-
-    loopCount += 1;
-    if (loopCount > 10) {
-      // stop searching after 10 ring searches
-      break;
-    }
-  }
-
-  return {
-    openServices: openServices.sort(sortByDistance).slice(0, limits.open),
-    nearbyServices: nearbyServices.sort(sortByDistance).slice(0, limits.nearby),
   };
 }
 

--- a/test/unit/lib/getPharmacies.js
+++ b/test/unit/lib/getPharmacies.js
@@ -36,7 +36,7 @@ describe('Nearby', () => {
       expect(results.openServices).is.not.equal(undefined);
     });
 
-    it('should get 10 nearby services by default, ordered by distance', () => {
+    it('should get 10 nearby pharmacies by default, ordered by distance', () => {
       const results = pharmacies.nearby(searchPoint, geo).nearbyServices;
 
       expect(results.length).to.be.equal(10);
@@ -74,7 +74,7 @@ describe('Nearby', () => {
       });
 
     it('should get the number of unique nearby services requested, ordered by distance', () => {
-      const requestedNumberOfResults = 52;
+      const requestedNumberOfResults = 51;
       const results =
         pharmacies
         .nearby(remoteSearchPoint, geo, { nearby: requestedNumberOfResults })
@@ -102,6 +102,12 @@ describe('Nearby', () => {
       const results = pharmacies.nearby(searchPoint, geo).nearbyServices;
 
       expect(results[0].identifier).to.be.equal(nearestIdentifier);
+    });
+
+    it('should return obj with 3 open orgs', () => {
+      const results = pharmacies.nearby(searchPoint, geo).openServices;
+
+      expect(results.length).is.equal(3);
     });
 
     it('should return the opening times message and open state', () => {
@@ -172,6 +178,7 @@ describe('Nearby', () => {
 
       const results = pharmacies.nearby(searchPoint, oneOrgGeo).nearbyServices;
 
+      expect(results.length).to.be.equal(1);
       expect(results[0].isOpen).to.be.equal(false);
       expect(results[0].openingTimesMessage).to.be.equal('Call for opening times');
     });
@@ -190,7 +197,6 @@ describe('Nearby', () => {
         .to.throw(AssertionError,
             'searchPoint must contain a property named longitude');
     });
-
     it('should throw exception when searchPoint does not contain latitude', () => {
       expect(() => { pharmacies.nearby({ longitude: -1.123456789 }); })
         .to.throw(


### PR DESCRIPTION
The same changes as for connecting-to-services in so far as going back to non-segment searches