### PR TITLE
:hankey: Ensure review apps have required env vars

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,12 @@
   "scripts": {
   },
   "env": {
+    "SPLUNK_HEC_ENDPOINT": {
+      "required": true
+    },
+    "SPLUNK_HEC_TOKEN": {
+      "required": true
+    }
   },
   "formation": {
     "web": {


### PR DESCRIPTION
Currently review apps are not having the env vars copied over from the main app, causing them to fail until the env vars are manually added. This change will automatically copy them over.