### PR TITLE
:question: Test running tests in foreground

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 script:
-  - docker-compose -f docker-compose-travis.yml up --build -d
+  - docker-compose -f docker-compose-travis.yml build nearby-services-api-tests
+  - docker-compose -f docker-compose-travis.yml run nearby-services-api-tests
 
 after_script:
   - docker-compose -f docker-compose-travis.yml down -v
@@ -22,3 +23,4 @@ after_success:
 env:
   matrix:
     secure: XoedU3vnz5Er1mmqOkZ4VID6xLig7meHCYMzP4MUIdxPJetZ2jRjFWm4rj+yMoREZBpXD46scFFPQ+BFEftmP0TU4/Gos49qlwxjGrDsEVVNw7XS70nyibBspvlurrMNuKogvRl+iNk/WP0a9t6uYFDdHQJ8AKlEZfKilkycI6tO4DaYXddRTfdwcPDQ4EjVjSJJp4ivhaPwqDVsNSg8rTzhyRMcCRg8UZ6IAdUOK5K6mGf5cBloRgjztoHP2hMaHS44C8cRcY9VEETfpxNYlc/XRAVBLHCN7JNQE/QN4GOVxtbXuZKKSCFJX0fs8NZAWKOiKA/4iOeSkQBljrRXFjZvpHcsciVxkjNvr3csaV6mH/LsOHl8ZyKvoEOXx5/NlbasLyiElnskMXQMhvXIJruSR/18uk3+LFrSBbczbw0+Lenu5zpsEjZShe9ijBgCAdr68iJwIxM1AicoNDbByGvzSaTQ8ISuO+TLiu3PupgTN6oE8z65GlWOA5abzqrroXprcMCGnMD9QVbhaz2ZxX9SuPNC40DEUnoisMuea6MIOF7PfHsEzrWoCdepaYC5JXZV6i1E4bS4zI4DsOa9Hu/Odi66nREn0qPht3BWs3p4iFrxLnlpMbNf0cSPvC1GUsDcplwDEuNxSac7tYpZA4xpx8HxjHns/8Jd0FXlKcE=
+

--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
 
-  nearby-services-api:
+  nearby-services-api-tests:
     build:
       context: .
       args:
@@ -10,16 +10,16 @@ services:
     command:
       sh -c "npm run git-hook && npm run snyk-test && npm run upload-coverage-coveralls"
     volumes:
-      - ./:/code
-      - api-travis-test-deps:/code/node_modules
+      - .:/code
+      - test-deps:/code/node_modules
     environment:
-      NODE_ENV: development
-      TRAVIS: 'true'
-      TRAVIS_JOB_ID: ${TRAVIS_JOB_ID}
-      TRAVIS_BRANCH: ${TRAVIS_BRANCH}
       COVERALLS_REPO_TOKEN: ${COVERALLS_REPO_TOKEN}
+      NODE_ENV: development
       SNYK_TOKEN: ${SNYK_TOKEN}
+      TRAVIS: ${TRAVIS}
+      TRAVIS_BRANCH: ${TRAVIS_BRANCH}
       TRAVIS_COMMIT: ${TRAVIS_COMMIT}
+      TRAVIS_JOB_ID: ${TRAVIS_JOB_ID}
     links:
       - mongodb-pharmacy:mongo
 
@@ -27,4 +27,5 @@ services:
     image: "nhsuk/mongodb-pharmacy:${MONGO_IMAGE_TAG-latest}"
 
 volumes:
-  api-travis-test-deps:
+  test-deps:
+


### PR DESCRIPTION
Build and run the test services via `docker-compose build` and `docker-compose run` rather than send them to the background using `docker-compose up -d` or exit when the service has finished its job via `docker-compose up --abort-on-container-exit`.

Alphabetise environment variables to ease seeing what has been set.