### PR TITLE
Remove un-needed image ENV setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ ARG NODE_ENV=production
 
 ENV NODE_ENV=${NODE_ENV}
 
-ENV DATETIME="${DATETIME}"
-
 COPY npm-shrinkwrap.json /code
 
 RUN if [ "$NODE_ENV" == "production" ]; then npm install --quiet --only=prod; else npm install --quiet ; fi


### PR DESCRIPTION
Having the env assignment is not needed as part of the image build
and could actually introduce problems.