### PR TITLE
:notebook: Log info as object for better analysis

### DIFF
--- a/app/lib/getNearbyServices.js
+++ b/app/lib/getNearbyServices.js
@@ -21,27 +21,27 @@ function getNearbyServices(searchPoint, limits, next) {
       },
     }]).toArray((errGeo, docs) => {
       if (errGeo) {
-        const errMsg = 'MongoDB error while making near query';
+        const errMsg = 'MongoDB error while making near query.';
         log.error({ err: new VError(errGeo, errMsg) }, errMsg);
         next(errGeo);
       }
 
-      log.debug(`Found ${docs.length} results for near search around [${searchPoint.coordinates}] (lon,lat)`);
+      log.info({ mongoDBResponse: { numberOfResults: docs.length, searchPoint: { type: 'Point', coordinates: searchPoint.coordinates } } }, 'MongoDB results returned.');
 
       const filteredServices = filterServices(docs, limits);
 
       db.close((errClose, result) => {
         if (errClose) {
-          const errMsg = 'MongoDB error while closing connection';
+          const errMsg = 'MongoDB error while closing connection.';
           log.error({ err: new VError(errClose, errMsg) }, errMsg);
           next(errClose);
         }
-        log.debug({ result }, 'Closed MongoDB connection');
+        log.debug({ result }, 'Closed MongoDB connection.');
         next(null, filteredServices);
       });
     });
   }).catch((err) => {
-    const errMsg = 'MongoDB error while making connection';
+    const errMsg = 'MongoDB error while making connection.';
     log.error({ err: new VError(err, errMsg) }, errMsg);
   });
 }

--- a/app/middleware/getServices.js
+++ b/app/middleware/getServices.js
@@ -1,6 +1,5 @@
 const getNearbyServices = require('../lib/getNearbyServices');
 const log = require('../lib/logger');
-const VError = require('verror').VError;
 
 function getServices(req, res, next) {
   req.checkQuery('latitude', 'latitude is required').notEmpty();
@@ -13,7 +12,7 @@ function getServices(req, res, next) {
   const errors = req.validationErrors();
 
   if (errors) {
-    log.warn(errors, 'getServices errors');
+    log.warn(errors, 'Errors found on request.');
     res.status(400).json(errors);
   } else {
     const latitude = parseFloat(req.query.latitude);
@@ -27,11 +26,8 @@ function getServices(req, res, next) {
     const searchPoint = { type: 'Point', coordinates: [longitude, latitude] };
     const limits = { nearby, open, searchRadius };
 
-    log.info('get-services-start');
     getNearbyServices(searchPoint, limits, (err, services) => {
       if (err) {
-        const errMsg = 'Error during attempt to get nearby services';
-        log.error({ err: new VError(err, errMsg) }, errMsg);
         res.status(500).send({ err });
         next(err);
       } else {
@@ -39,7 +35,6 @@ function getServices(req, res, next) {
         next();
       }
     });
-    log.info('get-services-end');
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -2,5 +2,5 @@ const log = require('./app/lib/logger');
 const app = require('./app');
 
 app.listen(app.port, () => {
-  log.info(`Express Finders-API server listening on port ${app.port}`);
+  log.info(`Express Finders-API server listening on port ${app.port}.`);
 });


### PR DESCRIPTION
Remove duplicated logging from middleware. Get the library to do the
logging.