### PR TITLE
:cop: Add and configure security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-0.11.0 / TBC
+0.10.0 / TBC
 ==================
 - Upgrade all npm dependencies
+- Add and configure security headers
 
-0.10.0 / 2017-09-08
+0.9.1 / 2017-09-08
 ==================
 - Switch to Elasticsearch back end
 - Upgrade to node 8.4.0

--- a/app.js
+++ b/app.js
@@ -13,7 +13,12 @@ promBundle.promClient.collectDefaultMetrics();
 applicationStarts.inc(1);
 
 app.use(promBundle.middleware);
-app.use(helmet());
+app.use(helmet({
+  frameguard: { action: 'deny' },
+  hsts: { includeSubDomains: false },
+  contentSecurityPolicy: { directives: { defaultSrc: ['\'self\''] } },
+  referrerPolicy: { policy: 'no-referrer' },
+}));
 app.use(validator());
 app.use('/nearby', getServices);
 

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -19,35 +19,6 @@ describe('app', function test() {
   const latitude = 53.797431921096;
   const coords = { latitude, longitude };
 
-  describe('security headers', () => {
-    it('should be returned for a valid request', (done) => {
-      chai.request(app)
-        .get('/nearby')
-        .query({ latitude, longitude })
-        .end((err, res) => {
-          expect(res).to.have.header('X-Xss-Protection', '1; mode=block');
-          expect(res).to.have.header('X-Frame-Options', 'SAMEORIGIN');
-          expect(res).to.have.header('X-Content-Type-Options', 'nosniff');
-          expect(res).to.have.header('X-Download-Options', 'noopen');
-          expect(res).to.not.have.header('X-Powered-By');
-          done();
-        });
-    });
-
-    it('should be returned for an invalid request', (done) => {
-      chai.request(app)
-        .get('/nearby')
-        .end((err, res) => {
-          expect(res).to.have.header('X-Xss-Protection', '1; mode=block');
-          expect(res).to.have.header('X-Frame-Options', 'SAMEORIGIN');
-          expect(res).to.have.header('X-Content-Type-Options', 'nosniff');
-          expect(res).to.have.header('X-Download-Options', 'noopen');
-          expect(res).to.not.have.header('X-Powered-By');
-          done();
-        });
-    });
-  });
-
   describe('nearby happy path', () => {
     it('should return an object containing 3 nearby and 1 open services by default', (done) => {
       chai.request(app)

--- a/test/integration/securityHeaders.js
+++ b/test/integration/securityHeaders.js
@@ -1,0 +1,33 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const app = require('../../app');
+const utils = require('./testUtils');
+
+const expect = chai.expect;
+
+chai.use(chaiHttp);
+
+describe('app', function test() {
+  // Setting this timeout as it is calling the real DB...
+  this.timeout(utils.maxWaitTimeMs);
+
+  before((done) => {
+    utils.waitForSiteReady(done);
+  });
+
+  it('security headers should be returned', (done) => {
+    chai.request(app)
+      .get('/nearby')
+      .end((err, res) => {
+        expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'');
+        expect(res).to.have.header('X-Xss-Protection', '1; mode=block');
+        expect(res).to.have.header('X-Frame-Options', 'DENY');
+        expect(res).to.have.header('X-Content-Type-Options', 'nosniff');
+        expect(res).to.have.header('X-Download-Options', 'noopen');
+        expect(res).to.not.have.header('X-Powered-By');
+        expect(res).to.have.header('Strict-Transport-Security', 'max-age=15552000');
+        expect(res).to.have.header('Referrer-policy', 'no-referrer');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
Brings the API response up from a [B](https://securityheaders.io/?q=https%3A%2F%2Fnearby-services-api.dev.beta.nhschoices.net%2Fnearby%3Flatitude%3D0%26longitude%3D0&hide=on&followRedirects=on) to an [A+](https://securityheaders.io/?q=https%3A%2F%2Fnearby-services-api-pr-103.dev.beta.nhschoices.net%2Fnearby&hide=on&followRedirects=on). Also excludes `subDomains` from the hsts header