### PR TITLE
set timezone for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.11.0 / 2017-10-17
+==================
+- Apply timezone when getting open messages
+
 0.10.1 / 2017-10-10
 ==================
 - Upgrade npm dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.11.0 / 2017-10-17
+0.10.2 / 2017-10-17
 ==================
 - Apply timezone when getting open messages
 

--- a/app/lib/getNearbyServices.js
+++ b/app/lib/getNearbyServices.js
@@ -52,13 +52,12 @@ async function getNearbyServices(searchCoordinates, limits) {
   try {
     totalTimer = esGetTotalPharmacyHistogram.startTimer();
 
-    const now = getDateTime();
-    const nowInTimezone = now.clone().tz(timezone);
+    const nowInTimezone = getDateTime().clone().tz(timezone);
     const openPharmacies = await getOpenPharmacies(nowInTimezone, searchCoordinates, limits);
     const nearbyPharmacies = await getNearbyPharmacies(searchCoordinates, limits);
     return {
-      nearbyServices: addMessages(nearbyPharmacies, now),
-      openServices: addMessages(openPharmacies, now),
+      nearbyServices: addMessages(nearbyPharmacies, nowInTimezone),
+      openServices: addMessages(openPharmacies, nowInTimezone),
     };
   } catch (err) {
     log.error({ err: new VError(err) });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nearby-services-api",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "private": true,
   "description": "nearby services api",
   "main": "server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nearby-services-api",
-  "version": "0.11.0",
+  "version": "0.10.2",
   "private": true,
   "description": "nearby services api",
   "main": "server.js",

--- a/test/unit/lib/addMessages.js
+++ b/test/unit/lib/addMessages.js
@@ -1,5 +1,7 @@
 const chai = require('chai');
 const moment = require('moment');
+require('moment-timezone');
+
 const addMessages = require('../../../app/lib/addMessages');
 
 const expect = chai.expect;
@@ -27,6 +29,31 @@ describe('addMessages', () => {
     expect(openServices.length).to.be.equal(1);
     expect(openServices[0].isOpen).to.be.equal(true);
     expect(openServices[0].openingTimesMessage).to.be.equal('Open 24 hours');
+  });
+
+  it('should return the opening times message and open state when between 12:00am and 01:00am Bristish Summer Time', () => {
+    const spanningSundayMidnightOrg = {
+      openingTimes: {
+        general: {
+          monday: [{ opens: '0:00', closes: '20:00' }, { opens: '23:00', closes: '23:59' }],
+          tuesday: [{ opens: '00:00', closes: '23:59' }],
+          wednesday: [{ opens: '00:00', closes: '23:59' }],
+          thursday: [{ opens: '00:00', closes: '23:59' }],
+          friday: [{ opens: '00:00', closes: '23:59' }],
+          saturday: [{ opens: '00:00', closes: '23:59' }],
+          sunday: [{ opens: '10:00', closes: '16:00' }, { opens: '23:00', closes: '23:59' }],
+        },
+      },
+    };
+    const pharmacies = [spanningSundayMidnightOrg];
+
+    const justAfterMidnightSundayBST = '2017-10-15T23:00:53.000Z';
+    // timezone required for correct results
+    const momentTime = moment(justAfterMidnightSundayBST).clone().tz('Europe/London');
+    const openServices = addMessages(pharmacies, momentTime);
+    expect(openServices.length).to.be.equal(1);
+    expect(openServices[0].openingTimesMessage).to.be.equal('Open until 8:00 pm today');
+    expect(openServices[0].isOpen).to.be.equal(true);
   });
 
   it('should use alterations opening times', () => {

--- a/test/unit/lib/addMessages.js
+++ b/test/unit/lib/addMessages.js
@@ -35,7 +35,7 @@ describe('addMessages', () => {
     const spanningSundayMidnightOrg = {
       openingTimes: {
         general: {
-          monday: [{ opens: '0:00', closes: '20:00' }, { opens: '23:00', closes: '23:59' }],
+          monday: [{ opens: '00:00', closes: '20:00' }, { opens: '23:00', closes: '23:59' }],
           tuesday: [{ opens: '00:00', closes: '23:59' }],
           wednesday: [{ opens: '00:00', closes: '23:59' }],
           thursday: [{ opens: '00:00', closes: '23:59' }],


### PR DESCRIPTION
Incorrect messages may appear if searching for times between 12am and 1am as the timezone is not being passed to the moment-opening-times library