### PR TITLE
:package: Update container to node:8.9.1-alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-0.11.1 / 2017-11-10
+0.12.0 / 2017-11-16
 ==================
+- Upgrade Docker container to `node:8.9.1-alpine`
+- Remove redundant `--` for forwarding script options
 - Round up to nearest minute in 'opening in' message
 
 0.11.0 / 2017-10-31

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.8.1-alpine
+FROM node:8.9.1-alpine
 RUN apk add --no-cache git
 
 ENV USERNAME nodeuser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nearby-services-api",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "description": "nearby services api",
   "main": "server.js",
@@ -21,7 +21,7 @@
     "test": "NODE_ENV=test mocha --exit --recursive test",
     "test-ci": "yarn lint && yarn coverage-generate && yarn coverage-check && yarn coverage-upload",
     "test-unit-watch": "NODE_ENV=test mocha --watch --recursive test/unit",
-    "test-watch": "yarn test -- --watch --reporter min"
+    "test-watch": "yarn test --watch --reporter min"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove `--` from passing options to scripts as it has been depcreated in
yarn 1+ and will change behaviour at some future point.