### PR TITLE
display correct opening times at 1 min to midnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.14.2 / TBA
+===================
+- Fix bug where closing time was wrong for service open past midnight when checking at 23:59
+
 0.14.1 / 2018-01-23
 ===================
 - Fix bug where opening time moment was changed to a string when spanning midnight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.14.2 / TBA
+0.14.2 / 2018-01-25
 ===================
 - Fix bug where closing time was wrong for service open past midnight when checking at 23:59
 

--- a/app/lib/midnightSpanCorrector.js
+++ b/app/lib/midnightSpanCorrector.js
@@ -32,16 +32,18 @@ function setNextClosedToTomorrow(openingTimes, status) {
   return status;
 }
 
-function correctClosedAt2359(status) {
+function correctClosedForOpeningSpansMidnight(status) {
   if (status.isOpen === false && status.moment.format('HH:mm') === '23:59') {
-    // eslint-disable-next-line no-param-reassign
+    /* eslint-disable no-param-reassign */
     status.isOpen = true;
+    status.nextOpen = status.moment;
+    /* eslint-enable */
   }
 }
 
 function midnightSpanCorrector(openingTimes, status) {
   if (openingSpansMidnight(openingTimes, status.nextClosed)) {
-    correctClosedAt2359(status);
+    correctClosedForOpeningSpansMidnight(status);
     return setNextClosedToTomorrow(openingTimes, status);
   }
   return status;

--- a/app/lib/midnightSpanCorrector.js
+++ b/app/lib/midnightSpanCorrector.js
@@ -18,7 +18,7 @@ function getNextClosedIgnoringMidnightSpan(openingTimes, nextClosed) {
   return tomorrowOpenStatus.nextClosed;
 }
 
-function setNextCloseToTomorrow(openingTimes, status) {
+function setNextClosedToTomorrow(openingTimes, status) {
   let nextClosed = getNextClosedIgnoringMidnightSpan(openingTimes, status.nextClosed);
   let count = 0;
   while (openingSpansMidnight(openingTimes, nextClosed) && count < maxDays) {
@@ -32,9 +32,17 @@ function setNextCloseToTomorrow(openingTimes, status) {
   return status;
 }
 
+function correctClosedAt2359(status) {
+  if (status.isOpen === false && status.moment.format('HH:mm') === '23:59') {
+    // eslint-disable-next-line no-param-reassign
+    status.isOpen = true;
+  }
+}
+
 function midnightSpanCorrector(openingTimes, status) {
   if (openingSpansMidnight(openingTimes, status.nextClosed)) {
-    return setNextCloseToTomorrow(openingTimes, status);
+    correctClosedAt2359(status);
+    return setNextClosedToTomorrow(openingTimes, status);
   }
   return status;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nearby-services-api",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "description": "nearby services api",
   "main": "server.js",

--- a/test/unit/lib/addMessages.js
+++ b/test/unit/lib/addMessages.js
@@ -21,6 +21,19 @@ describe('addMessages', () => {
       },
     },
   };
+  const spanningSundayMidnightOrg = {
+    openingTimes: {
+      general: {
+        monday: [{ opens: '00:00', closes: '20:00' }, { opens: '23:00', closes: '23:59' }],
+        tuesday: [{ opens: '00:00', closes: '23:59' }],
+        wednesday: [{ opens: '00:00', closes: '23:59' }],
+        thursday: [{ opens: '00:00', closes: '23:59' }],
+        friday: [{ opens: '00:00', closes: '23:59' }],
+        saturday: [{ opens: '00:00', closes: '23:59' }],
+        sunday: [{ opens: '10:00', closes: '16:00' }, { opens: '23:00', closes: '23:59' }],
+      },
+    },
+  };
 
   it('should return the opening times message, open status, openingTimesOverview, and next open', () => {
     const momentString = '2017-01-02 11:00';
@@ -41,19 +54,7 @@ describe('addMessages', () => {
   it('should return the opening times message, open status and next open when between 12:00am and 01:00am British Summer Time', () => {
     const justAfterMidnightSundayBST = '2017-10-15T23:00:53.000Z';
     const nextOpenDateString = new Date(justAfterMidnightSundayBST).toDateString();
-    const spanningSundayMidnightOrg = {
-      openingTimes: {
-        general: {
-          monday: [{ opens: '00:00', closes: '20:00' }, { opens: '23:00', closes: '23:59' }],
-          tuesday: [{ opens: '00:00', closes: '23:59' }],
-          wednesday: [{ opens: '00:00', closes: '23:59' }],
-          thursday: [{ opens: '00:00', closes: '23:59' }],
-          friday: [{ opens: '00:00', closes: '23:59' }],
-          saturday: [{ opens: '00:00', closes: '23:59' }],
-          sunday: [{ opens: '10:00', closes: '16:00' }, { opens: '23:00', closes: '23:59' }],
-        },
-      },
-    };
+
     const pharmacies = [spanningSundayMidnightOrg];
 
     // timezone required for correct results
@@ -61,6 +62,40 @@ describe('addMessages', () => {
     const openServices = addMessages(pharmacies, momentTime);
     expect(openServices.length).to.be.equal(1);
     expect(openServices[0].openingTimesMessage).to.be.equal('Open until 8pm today');
+    expect(openServices[0].isOpen).to.be.equal(true);
+    expect(openServices[0].openingTimesOverview).to.not.be.undefined;
+    expect(openServices[0].nextOpen).to.not.be.undefined;
+    expect(new Date(openServices[0].nextOpen).toDateString()).to.be.equal(nextOpenDateString);
+  });
+
+  it('should return the opening times message, open status and next open when between 12:00am and 01:00am British Summer Time', () => {
+    const justAfterMidnightSundayBST = '2017-10-15T22:00:53.000Z';
+    const nextOpenDateString = new Date(justAfterMidnightSundayBST).toDateString();
+
+    const pharmacies = [spanningSundayMidnightOrg];
+
+    // timezone required for correct results
+    const momentTime = moment(justAfterMidnightSundayBST).clone().tz('Europe/London');
+    const openServices = addMessages(pharmacies, momentTime);
+    expect(openServices.length).to.be.equal(1);
+    expect(openServices[0].openingTimesMessage).to.be.equal('Open until 8pm tomorrow');
+    expect(openServices[0].isOpen).to.be.equal(true);
+    expect(openServices[0].openingTimesOverview).to.not.be.undefined;
+    expect(openServices[0].nextOpen).to.not.be.undefined;
+    expect(new Date(openServices[0].nextOpen).toDateString()).to.be.equal(nextOpenDateString);
+  });
+
+  it('should return the opening times message, open status and next open when between 12:00am and 01:00am British Summer Time', () => {
+    const justAfterMidnightSundayBST = '2017-10-15T22:59:00.000Z';
+    const nextOpenDateString = new Date(justAfterMidnightSundayBST).toDateString();
+
+    const pharmacies = [spanningSundayMidnightOrg];
+
+    // timezone required for correct results
+    const momentTime = moment(justAfterMidnightSundayBST).clone().tz('Europe/London');
+    const openServices = addMessages(pharmacies, momentTime);
+    expect(openServices.length).to.be.equal(1);
+    expect(openServices[0].openingTimesMessage).to.be.equal('Open until 8pm tomorrow');
     expect(openServices[0].isOpen).to.be.equal(true);
     expect(openServices[0].openingTimesOverview).to.not.be.undefined;
     expect(openServices[0].nextOpen).to.not.be.undefined;

--- a/test/unit/lib/addMessages.js
+++ b/test/unit/lib/addMessages.js
@@ -68,14 +68,14 @@ describe('addMessages', () => {
     expect(new Date(openServices[0].nextOpen).toDateString()).to.be.equal(nextOpenDateString);
   });
 
-  it('should return the opening times message, open status and next open when between 12:00am and 01:00am British Summer Time', () => {
-    const justAfterMidnightSundayBST = '2017-10-15T22:00:53.000Z';
-    const nextOpenDateString = new Date(justAfterMidnightSundayBST).toDateString();
+  it('should return the opening times message, open status and next open when before 12:00am British Summer Time', () => {
+    const beforeMidnightSundayBST = '2017-10-15T22:00:53.000Z';
+    const nextOpenDateString = new Date(beforeMidnightSundayBST).toDateString();
 
     const pharmacies = [spanningSundayMidnightOrg];
 
     // timezone required for correct results
-    const momentTime = moment(justAfterMidnightSundayBST).clone().tz('Europe/London');
+    const momentTime = moment(beforeMidnightSundayBST).clone().tz('Europe/London');
     const openServices = addMessages(pharmacies, momentTime);
     expect(openServices.length).to.be.equal(1);
     expect(openServices[0].openingTimesMessage).to.be.equal('Open until 8pm tomorrow');
@@ -85,14 +85,14 @@ describe('addMessages', () => {
     expect(new Date(openServices[0].nextOpen).toDateString()).to.be.equal(nextOpenDateString);
   });
 
-  it('should return the opening times message, open status and next open when between 12:00am and 01:00am British Summer Time', () => {
-    const justAfterMidnightSundayBST = '2017-10-15T22:59:00.000Z';
-    const nextOpenDateString = new Date(justAfterMidnightSundayBST).toDateString();
+  it('should return the opening times message, open status and next open when one minute before 12:00am British Summer Time', () => {
+    const justBeforeMidnightSundayBST = '2017-10-15T22:59:00.000Z';
+    const nextOpenDateString = new Date(justBeforeMidnightSundayBST).toDateString();
 
     const pharmacies = [spanningSundayMidnightOrg];
 
     // timezone required for correct results
-    const momentTime = moment(justAfterMidnightSundayBST).clone().tz('Europe/London');
+    const momentTime = moment(justBeforeMidnightSundayBST).clone().tz('Europe/London');
     const openServices = addMessages(pharmacies, momentTime);
     expect(openServices.length).to.be.equal(1);
     expect(openServices[0].openingTimesMessage).to.be.equal('Open until 8pm tomorrow');

--- a/test/unit/lib/midnightSpanCorrector.js
+++ b/test/unit/lib/midnightSpanCorrector.js
@@ -112,6 +112,18 @@ describe('Midnight Span Corrector', () => {
       expect(newStatus.nextOpen).to.be.instanceOf(Moment);
     });
 
+    it('should say open and use next day\'s closing time for a close at 23:59 and open at 00:00 the next day', () => {
+      const openingTimesJson = getRegularWorkingWeekAbuttingMidnightAt2359();
+      const openingTimes = getNewOpeningTimes(openingTimesJson, timeZone);
+      const moment = getMoment('monday', 23, 59, timeZone);
+      const status = openingTimes.getStatus(moment, { next: true });
+
+      const newStatus = midnightSpanCorrector(openingTimes, status);
+      momentsShouldBeSame(newStatus.nextClosed, getMoment('tuesday', 20, 0, timeZone));
+      expect(newStatus.nextOpen).to.be.instanceOf(Moment);
+      expect(newStatus.isOpen).to.be.true;
+    });
+
     it('should not correct time if closes at 23:59 opens later than 00:00 the next day', () => {
       const openingTimesJson = getRegularWorkingWeekAbuttingMidnightAt2359();
       const openingTimes = getNewOpeningTimes(openingTimesJson, timeZone);


### PR DESCRIPTION
Times spanning midnight are shown as closing at 23:59 by convention.
If these are viewed at 23:59 they show as closed and opening at 00:00 the next day.

This can be replicated in the nearby-services-api by setting the time to 23:59 via the env var, i.e.
export DATETIME=2018-01-21T23:59:00

And querying the API via:
http://localhost:3001/nearby?latitude=53.805625915527344&longitude=-1.5685086250305176&limits:results=1

The message should be 'Open until 8pm tomorrow' when fixed.